### PR TITLE
Add `view` to `IModuleManager.isModule`

### DIFF
--- a/contracts/interfaces/IModuleManager.sol
+++ b/contracts/interfaces/IModuleManager.sol
@@ -46,7 +46,7 @@ interface IModuleManager {
      * @param addr address - Address to check
      * @return bool - True if the address is a module, false otherwise
      */
-    function isModule(address addr) external returns (bool);
+    function isModule(address addr) external view returns (bool);
 
     /**
      * @notice Get the list of modules


### PR DESCRIPTION
The function `isModule` is declared as `view` in the ModuleManager contract, but is missing that keyword in its interface. Therefore, currently I cannot use `IModuleManager(msg.sender).isModule(moduleAddress)` in my own view functions.