### PR TITLE
[clave-contracts] fix: change the P256_VERIFIER address to precompile

### DIFF
--- a/contracts/validators/PasskeyValidator.sol
+++ b/contracts/validators/PasskeyValidator.sol
@@ -11,7 +11,7 @@ import {VerifierCaller} from '../helpers/VerifierCaller.sol';
  * @author https://getclave.io
  */
 contract PasskeyValidator is IR1Validator, VerifierCaller {
-    address constant P256_VERIFIER = 0x840Fec7b1615375E66f9631aBdA962dADeBFFf20;
+    address constant P256_VERIFIER = 0x0000000000000000000000000000000000000100;
     string constant ClIENT_DATA_PREFIX = '{"type":"webauthn.get","challenge":"';
     string constant IOS_ClIENT_DATA_SUFFIX = '","origin":"https://getclave.io"}';
     string constant ANDROID_ClIENT_DATA_SUFFIX =


### PR DESCRIPTION
# WHAT

Replaced the P256_VERIFIER address with the RIP-7212 precompile address (0x100)

# WHY

The previous verifier only works with whitelisted RPC and needs to be replaced with precompile. Current Clave accounts also use this address.