### PR TITLE
Declare visibility of `cloudGuardian`

### DIFF
--- a/contracts/modules/recovery/CloudRecoveryModule.sol
+++ b/contracts/modules/recovery/CloudRecoveryModule.sol
@@ -23,7 +23,7 @@ contract CloudRecoveryModule is BaseRecovery {
     uint256 public immutable TIMELOCK;
 
     // Cloud guardian addresses for each account
-    mapping(address => address) cloudGuardian;
+    mapping(address => address) public cloudGuardian;
 
     /**
      * @notice Emitted when a new cloud guardian is set for an account


### PR DESCRIPTION
I'd go so far as to suggest to rename this variable to `getGuardian` to provide the built-in view and removing the `getGuardian()` helper view.